### PR TITLE
Fix README typos and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐾 Pet Age Calculator
 
-A responsive, theme-aware web app that converts pet years to human years and vice versa for dogs and cats. This projects pupose is to continue my passion for front-end development. This is an excuse to practice form handling, dark mode theming, and clean UI/UX with Tailwind CSS and DaisyUI. It is also a handy utility 😊
+A responsive, theme-aware web app that converts pet years to human years and vice versa for dogs and cats. This project's purpose is to continue my passion for front-end development. This is an excuse to practice form handling, dark mode theming, and clean UI/UX with Tailwind CSS and DaisyUI. It is also a handy utility 😊
 
 ## 🌟 Features
 
@@ -32,7 +32,7 @@ A responsive, theme-aware web app that converts pet years to human years and vic
 
 ## 📸 Preview
 
-![Pet Age Calculator Screenshot](/public//Screenshot.png)
+![Pet Age Calculator Screenshot](/public/Screenshot.png)
 
 _Theme-aware, mobile-friendly design with interactive UI components.
 
@@ -85,42 +85,5 @@ git clone https://github.com/RW2023/pet-age-calculator.git
 cd pet-age-calculator
 npm install
 npm run dev
-
-
-
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
-
-## Getting Started
-
-First, run the development server:
-
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "daisyui": "^5.0.43",
@@ -27,6 +28,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/lib/__tests__/calculateAge.test.ts
+++ b/src/lib/__tests__/calculateAge.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateDogToHuman,
+  calculateDogToPet,
+  calculateCatToHuman,
+  calculateCatToPet,
+  default as calculatePetAge,
+} from '../calculateAge';
+
+describe('calculateAge utilities', () => {
+  it('converts dog years to human years', () => {
+    expect(calculateDogToHuman(1)).toBe(15);
+    expect(calculateDogToHuman(5, 'large')).toBe(42);
+  });
+
+  it('converts human years to dog years', () => {
+    expect(calculateDogToPet(20)).toBe(2);
+    expect(calculateDogToPet(50, 'large')).toBeCloseTo(6.3, 1);
+  });
+
+  it('converts cat years to human years', () => {
+    expect(calculateCatToHuman(3)).toBe(28);
+  });
+
+  it('converts human years to cat years', () => {
+    expect(calculateCatToPet(28)).toBe(3);
+  });
+
+  it('uses the generic calculatePetAge function', () => {
+    expect(calculatePetAge('dog', 'toHuman', 2)).toMatch('about 24');
+    expect(calculatePetAge('cat', 'toPet', 28)).toMatch('about 3');
+  });
+});


### PR DESCRIPTION
## Summary
- correct typos and clean up README
- update screenshot path
- add test suite for calculateAge utilities
- expose `npm test` script with vitest

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421a68ea84832abe069d0548cd6b12